### PR TITLE
Omniauth

### DIFF
--- a/.env.development.example
+++ b/.env.development.example
@@ -37,3 +37,5 @@ SMTP_USERNAME=your_username
 SMTP_PASSWORD=your_password
 SMTP_AUTHENTICATION=plain
 SMTP_ENABLE_STARTTLS_AUTO=true
+GOOGLE_CLIENT_ID=your_client_id_value
+GOOGLE_CLIENT_SECRET=your_client_secret_value

--- a/Gemfile
+++ b/Gemfile
@@ -86,3 +86,8 @@ gem 'graphql'
 gem 'jwt'
 
 gem 'csv'
+
+gem 'devise'
+gem 'omniauth'
+gem 'omniauth-google-oauth2'
+gem 'omniauth-rails_csrf_protection'

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+# SessionsController handles authentication and session management.
+class SessionsController < ApplicationController
+  def create_from_oauth(auth)
+    user = User.from_omniauth(auth)
+    if user
+      session[:user_id] = user.id
+      redirect_to root_path, notice: 'Logged in successfully.'
+    else
+      redirect_to root_path, alert: 'Failed to authenticate with the provider.'
+    end
+  end
+end

--- a/app/model/user.rb
+++ b/app/model/user.rb
@@ -1,0 +1,12 @@
+# frozen_string_literal: true
+
+# User model represents a user in the application.
+class User < ApplicationRecord
+  def self.from_omniauth(auth)
+    where(provider: auth.provider, uid: auth.uid).first_or_create do |user|
+      user.email = auth.info.email
+      user.name = auth.info.name
+      user.password = Devise.friendly_token[0, 20]
+    end
+  end
+end

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,16 +1,1 @@
-<!DOCTYPE html>
-<html>
-  <head>
-    <title>Zonketest</title>
-    <meta name="viewport" content="width=device-width,initial-scale=1">
-    <%= csrf_meta_tags %>
-    <%= csp_meta_tag %>
-
-    <%= stylesheet_link_tag "application", "data-turbo-track": "reload" %>
-    <%= javascript_importmap_tags %>
-  </head>
-
-  <body>
-    <%= yield %>
-  </body>
-</html>
+<%= link_to 'Sign in with Google', '/auth/google_oauth2' %>

--- a/config/initializers/omniauth.rb
+++ b/config/initializers/omniauth.rb
@@ -1,0 +1,10 @@
+# frozen_string_literal: true
+
+Rails.application.config.middleware.use OmniAuth::Builder do
+  provider :google_oauth2, ENV.fetch('GOOGLE_CLIENT_ID'), ENV.fetch('GOOGLE_CLIENT_SECRET'),
+           {
+             scope: 'email, profile',
+             prompt: 'select_account, consent',
+             redirect_uri: '/auth/google/callback'
+           }
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,4 +16,6 @@ Rails.application.routes.draw do
 
   mount GraphiQL::Rails::Engine, at: '/graphiql', graphql_path: '/graphql'
   post '/graphql', to: 'graphql#execute'
+
+  get '/auth/:provider/callback', to: 'sessions#create_from_google'
 end


### PR DESCRIPTION
# OmniAuth Integration

This integration allows your application to easily authenticate with third-party providers.

## Configuration

To configure this feature, you need to set the following environment variables:

- `GOOGLE_CLIENT_ID`: The API key for the OmniAuth provider.
- `GOOGLE_CLIENT_SECRET`: The API secret for the OmniAuth provider.

## Setup

* Copy `.env.development.example` to `.env.development`:
  ```
  cp .env.development.example .env.development
  ```

## Testing

1. Start the Rails server by running `rails server`.

2. In your web browser, navigate to the login page of your application.

3. Click on the "Sign in with Google" button.

4. You will be redirected to Google's authentication page. Select your Google account and grant the necessary permissions.

5. After successful authentication, you should be redirected back to your application.

6. Verify that the user was created in the database by checking the database records or using the Rails console.
